### PR TITLE
Replace "chef/debian-7.4" image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - composer install
   - mkdir ${TRAVIS_BUILD_DIR}/src/typo3_src-${TYPO3_VERSION} && cd ${TRAVIS_BUILD_DIR}/src/typo3_src-${TYPO3_VERSION} && wget https://github.com/TYPO3/TYPO3.CMS/archive/${TYPO3_VERSION}.tar.gz && tar --strip-components=1 -xzf ${TYPO3_VERSION}.tar.gz
   - ln -nfs ${TRAVIS_BUILD_DIR}/src/typo3_src-${TYPO3_VERSION} ${TRAVIS_BUILD_DIR}/src/typo3_src
+  - composer install -d ${TRAVIS_BUILD_DIR}/src/typo3_src
 before_script:
   - mysql -e 'CREATE DATABASE typo3;'
   - mysql typo3 < ${TRAVIS_BUILD_DIR}/provision/database.sql

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: php
 php: [5.5, 5.4]
 env:
   - TYPO3_VERSION=master
-  - TYPO3_VERSION=TYPO3_6-2-3
-  - TYPO3_VERSION=TYPO3_6-1-9
-  - TYPO3_VERSION=TYPO3_6-0-14
+  - TYPO3_VERSION=TYPO3_6-2-15
 services: [mysql]
 install:
   - composer install
@@ -12,7 +10,7 @@ install:
   - ln -nfs ${TRAVIS_BUILD_DIR}/src/typo3_src-${TYPO3_VERSION} ${TRAVIS_BUILD_DIR}/src/typo3_src
 before_script:
   - mysql -e 'CREATE DATABASE typo3;'
-  - mysql typo3 < ${TRAVIS_BUILD_DIR}/provision/database.sql 
+  - mysql typo3 < ${TRAVIS_BUILD_DIR}/provision/database.sql
 script:
   - cd ${TRAVIS_BUILD_DIR}
   - bin/phing

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 php: [5.6, 5.5, 5.4]
 env:
-  - TYPO3_VERSION=TYPO3_7-6-0
-  - TYPO3_VERSION=TYPO3_7-5-0
   - TYPO3_VERSION=TYPO3_6-2-15
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: php
 php: [5.6, 5.5, 5.4]
 env:
-  - TYPO3_VERSION=master
+  - TYPO3_VERSION=TYPO3_7-6-0
+  - TYPO3_VERSION=TYPO3_7-5-0
   - TYPO3_VERSION=TYPO3_6-2-15
+matrix:
+  exclude:
+    - php: 5.4
+      env: TYPO3_VERSION=TYPO3_7-6-0
+    - php: 5.4
+      env: TYPO3_VERSION=TYPO3_7-5-0
+
 services: [mysql]
 install:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-php: [5.5, 5.4]
+php: [5.6, 5.5, 5.4]
 env:
   - TYPO3_VERSION=master
   - TYPO3_VERSION=TYPO3_6-2-15

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "debian/wheezy64"
 
+  # Example config for exposing the HTTP port.
+  # Don't use this in your CI environment when multiple builds run in parallel
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
   # Provision your virtual machine with ansible.
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "provision.yaml"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "chef/debian-7.4"
+  config.vm.box = "debian/wheezy64"
 
   # Provision your virtual machine with ansible.
   config.vm.provision "ansible" do |ansible|

--- a/provision.yaml
+++ b/provision.yaml
@@ -56,6 +56,12 @@
       notify: [restart apache]
     - copy: src=provision/apache_vhost dest=/etc/apache2/sites-available/default
       notify: [restart apache]
+    - lineinfile: dest=/etc/apache2/envvars regexp="^export APACHE_RUN_USER=.*" line="export APACHE_RUN_USER=vagrant"
+      notify: [restart apache]
+    - lineinfile: dest=/etc/apache2/envvars regexp="^export APACHE_RUN_GROUP=.*" line="export APACHE_RUN_GROUP=vagrant"
+      notify: [restart apache]
+    - name: DIE FUCKING APACHE DIE DIE DIE
+      file: path=/var/lock/apache2 owner=vagrant group=vagrant
 
     # TYPO3 setup
     - shell: mkdir -p /vagrant/src/typo3_src-{{ typo3_version }} && cd /vagrant/src/typo3_src-{{ typo3_version }} && wget https://github.com/TYPO3/TYPO3.CMS/archive/{{ typo3_version }}.tar.gz && tar --strip-components=1 -xzf {{ typo3_version }}.tar.gz && chown vagrant . -R


### PR DESCRIPTION
As reported in #2, the `chef/debian-7.4` image does not exist anymore. Replace it with an official Debian image.

Fixes #2
